### PR TITLE
Fixes #51 - change deprecated import from IPython.core

### DIFF
--- a/src/pozo/renderers/tree_table.py
+++ b/src/pozo/renderers/tree_table.py
@@ -1,5 +1,5 @@
 import pozo.renderers as pzr
-from IPython.core.display import HTML, display, Javascript
+from IPython.display import HTML, display, Javascript
 import html
 
 def javascript():


### PR DESCRIPTION
https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#pending-deprecated-imports